### PR TITLE
Make lich compile in macOS/clang

### DIFF
--- a/lich/pcall.h
+++ b/lich/pcall.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <tuple>
 #include <cassert>
+#include <string>
 
 namespace lich
 {

--- a/test/build-lua.c
+++ b/test/build-lua.c
@@ -5,6 +5,7 @@
 #endif
 
 #define __STRICT_ANSI__
+#define _ANSI_SOURCE
 
 #define LUA_TMPNAMBUFSIZE 32
 #define lua_tmpnam(buff, err) buff[0]=0;err=0;


### PR DESCRIPTION
`#include <string>`이 빠져 생기는 문제와, Lua 5.1이 POSIX 2008 함수와 충돌해서 생기는 문제를 해결합니다.
